### PR TITLE
(fix) Mock persist method for syntethic events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -351,6 +351,11 @@ function executeResponder(e: IEvent, checker: ICheckerWrapper[]) {
   }
 }
 
+/**
+ * Noop function used for mocking React Syntethic methods
+ */
+function noop() {}
+
 function eventListener(e: Event) {
   const plugin = getPlugin();
 
@@ -363,6 +368,7 @@ function eventListener(e: Event) {
   }
 
   (e as IEvent).nativeEvent = result.nativeEvent;
+  (e as any).persist = noop;
 
   const { p, pr } = getEventPaths(e as IEvent);
   const checkers = getCheckers(e.type, p as HTMLElement[], pr as HTMLElement[]);


### PR DESCRIPTION
I've stumbled on another error, when using anything touchable with `react-native-web`. Seems that `RNW` calls `.persist()` on react's synthetic event, to be able to process the _real_ event.

You can find the usage here https://github.com/necolas/react-native-web/blob/4f5de8d016e1bc3b5d91ffda6ac8b3a4ad2cb8ea/packages/react-native-web/src/exports/ScrollView/ScrollViewBase.js#L157 and in here https://github.com/necolas/react-native-web/blob/36dacb2052efdab2a28655773dc76934157d9134/packages/react-native-web/src/exports/Touchable/index.js#L391